### PR TITLE
Skip auth only if the current principal is for the expected SP

### DIFF
--- a/src/main/java/idensys/saml/IdentityProviderAuthnFilter.java
+++ b/src/main/java/idensys/saml/IdentityProviderAuthnFilter.java
@@ -58,13 +58,13 @@ public class IdentityProviderAuthnFilter extends OncePerRequestFilter implements
     AuthnRequest authnRequest = (AuthnRequest) messageContext.getInboundSAMLMessage();
 
     if (authenticationNotRequired(authnRequest.getIssuer())) {
-        sendAuthResponse(response);
-        return;
-      }
+      sendAuthResponse(response);
+      return;
+    }
 
     SAMLPrincipal principal = new SAMLPrincipal(authnRequest.getIssuer().getValue(), authnRequest.getID(),
       authnRequest.getAssertionConsumerServiceURL(), messageContext.getRelayState());
-    
+
     validateAssertionConsumerService(principal);
 
     SecurityContextHolder.getContext().setAuthentication(new SAMLAuthentication(principal));
@@ -108,10 +108,10 @@ public class IdentityProviderAuthnFilter extends OncePerRequestFilter implements
   private boolean authenticationNotRequired(Issuer authRequestIssuer) {
     Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();
     if (existingAuth != null && existingAuth.getPrincipal() instanceof SAMLPrincipal && existingAuth.isAuthenticated()) {
-        SAMLPrincipal existingSAMLAuth = (SAMLPrincipal) existingAuth.getPrincipal();
+      SAMLPrincipal existingSAMLAuth = (SAMLPrincipal) existingAuth.getPrincipal();
         
-        // Skip authentication only if the existing principal is for the requesting service provider
-        return existingSAMLAuth.getServiceProviderEntityID().equals(authRequestIssuer.getValue());
+      // Skip authentication only if the existing principal is for the requesting service provider
+      return existingSAMLAuth.getServiceProviderEntityID().equals(authRequestIssuer.getValue());
     }
     return false;
   }


### PR DESCRIPTION
I'm not sure this is the right way - Maybe the idea here is to avoid going back to the IdP for each new service provider, in which case we should perhaps look to change how the principal is used to avoid it 'locking-in' to the first service provider used. It's also entirely possible I've misconfigured or misunderstood something about how the proxy is supposed to work - Pointers much appreciated if so!

Fixes issue #1